### PR TITLE
Partner whitelist

### DIFF
--- a/src/PeggedTokenConverter.sol
+++ b/src/PeggedTokenConverter.sol
@@ -25,12 +25,12 @@ contract PeggedTokenConverter is
     bool public bidirectional;
     mapping(address => bool) public partners;
 
-    event Deposit(address indexed token, uint256 amount);
-    event Withdraw(address indexed token, uint256 amount);
-    event Convert(address indexed user, address indexed inputToken, uint256 amount);
-    event ToggleBidirectional(bool currStatus);
-    event PartnerAdded(address partner);
-    event PartnerRemoved(address partner);
+    event Deposit(address indexed token, uint256 indexed amount);
+    event Withdraw(address indexed token, uint256 indexed amount);
+    event Convert(address indexed user, address indexed inputToken, uint256 indexed amount);
+    event ToggleBidirectional(bool indexed currStatus);
+    event PartnerAdded(address indexed partner);
+    event PartnerRemoved(address indexed partner);
 
     constructor() {
         _disableInitializers();

--- a/src/PeggedTokenConverter.sol
+++ b/src/PeggedTokenConverter.sol
@@ -23,12 +23,15 @@ contract PeggedTokenConverter is
     IERC20 public tokenA;
     IERC20 public tokenB;
     bool public bidirectional;
+    mapping(address => bool) public partners;
 
     event Deposit(address indexed token, uint256 amount);
     event Withdraw(address indexed token, uint256 amount);
     event Convert(address indexed user, address indexed inputToken, uint256 amount);
     event ToggleBidirectional(bool currStatus);
-    
+    event PartnerAdded(address partner);
+    event PartnerRemoved(address partner);
+
     constructor() {
         _disableInitializers();
     }
@@ -56,8 +59,10 @@ contract PeggedTokenConverter is
     function convert(address _token, uint256 _amount) external {
         require(_token == address(tokenA) || _token == address(tokenB), "Invalid token type");
         require(_amount > 0, "No zero convert");
-        if(!bidirectional && _token != address(tokenA)) {
-            revert("Conversions paused");
+        if(_token != address(tokenA)) {
+            if(!bidirectional && !partners[msg.sender]) {
+                revert("Conversions paused");
+            }
         }
 
         IERC20 inputToken;
@@ -120,6 +125,28 @@ contract PeggedTokenConverter is
         bool current = bidirectional;
         bidirectional = !current;
         emit ToggleBidirectional(bidirectional);
+    }
+
+    /**
+     * @dev Adds a partner to the whitelist
+     * @param _partner The address of the partner
+     */
+    function addPartner(address _partner) external onlyOwner {
+        require(_partner != address(0), "Invalid address");
+        require(!partners[_partner], "Partner already on whitelist");
+        partners[_partner] = true;
+        emit PartnerAdded(_partner);
+    }
+
+    /**
+     * @dev Removes a partner to the whitelist
+     * @param _partner The address of the partner
+     */
+    function removePartner(address _partner) external onlyOwner {
+        require(_partner != address(0), "Invalid address");
+        require(partners[_partner], "Partner not on whitelist");
+        partners[_partner] = false;
+        emit PartnerRemoved(_partner);
     }
 
     // ------------------------- Viewers -------------------------

--- a/src/PeggedTokenConverter.sol
+++ b/src/PeggedTokenConverter.sol
@@ -12,8 +12,10 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
  * @notice A bidirectional ERC20 token converter.
  * @dev This converter:
  *      - Allows owner to deposit tokens
- *      - Enables users to convert tokens at 1:1 ratio
  *      - Allows owner to withdraw tokens
+ *      - Enables users to convert input-to-output tokens at 1:1 ratio
+ *      - Whitelisted partners can access the output-to-input token conversion route
+ *      - If 'bidirectional' is enabled, all users can access both routes
  */
 contract PeggedTokenConverter is
     Ownable2StepUpgradeable

--- a/test/PeggedTokenConverter.t.sol
+++ b/test/PeggedTokenConverter.t.sol
@@ -331,4 +331,61 @@ contract PeggedTokenConverterTest is Test {
         uint256 userTokenBBalance = tokenB.balanceOf(emily);
         assertEq(userTokenBBalance, 0);
     }
+
+    function test_addRemovePartner() public {
+        assertEq(converter.partners(emily), false);
+
+        // Add emily as partner
+        vm.startPrank(owner);
+        converter.addPartner(emily);
+        assertEq(converter.partners(emily), true);
+
+        // Remove emily as partner
+        converter.removePartner(emily);
+        assertEq(converter.partners(emily), false);
+    }
+
+    function test_partnerBidirectional() public {
+        // Global bidirectional is false
+        assertEq(converter.bidirectional(), false);
+
+        // Add emily as partner
+        vm.startPrank(owner);
+        converter.addPartner(emily);
+        assertEq(converter.partners(emily), true);
+
+        uint256 amount = 10 ether;
+        tokenB.mint(emily, amount);
+
+        // Owner deposits liquidity for both token types
+        uint256 depositAmount = 50 ether;
+        vm.startPrank(owner);
+        tokenA.approve(address(converter), depositAmount);
+        converter.deposit(address(tokenA), depositAmount);
+        tokenB.approve(address(converter), depositAmount);
+        converter.deposit(address(tokenB), depositAmount);
+
+        // Check contract balances pre-conversion
+        uint256 contractTokenABalancePre = tokenA.balanceOf(address(converter));
+        assertEq(contractTokenABalancePre, depositAmount);
+        uint256 contractTokenBBalancePre = tokenB.balanceOf(address(converter));
+        assertEq(contractTokenBBalancePre, depositAmount);
+
+        // Partners's conversion attempt should be successful despite global bidirectionality turned off
+        vm.startPrank(emily);
+        tokenB.approve(address(converter), amount);
+        converter.convert(address(tokenB), amount);
+
+        // Check contract balances post-conversion
+        uint256 contractTokenABalancePost = tokenA.balanceOf(address(converter));
+        assertEq(contractTokenABalancePost, contractTokenABalancePre-amount);
+        uint256 contractTokenBBalancePost = tokenB.balanceOf(address(converter));
+        assertEq(contractTokenBBalancePost, contractTokenBBalancePre+amount);
+
+        // Check user balances
+        uint256 userTokenABalance = tokenA.balanceOf(emily);
+        assertEq(userTokenABalance, amount);
+        uint256 userTokenBBalance = tokenB.balanceOf(emily);
+        assertEq(userTokenBBalance, 0);
+    }
 }


### PR DESCRIPTION
This PR adds a partner whitelist that has constant access to bidirectional conversions, even if the global `bidirectional` access is turned off.